### PR TITLE
Add SplitReader (https://github.com/tolik505/split-csv/issues/11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .DS_Store
+coverage.out
 testdata/.DS_Store
 testdata/big.csv
 testdata/result_custom_reader/test_1.csv

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .DS_Store
 testdata/.DS_Store
 testdata/big.csv
+testdata/result_custom_reader/test_1.csv
+testdata/result_custom_reader/test_2.csv
+testdata/result_custom_reader/test_3.csv
 testdata/result_default/test_1.csv
 testdata/result_default/test_2.csv
 testdata/result_default/test_3.csv

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center"><a href="https://godoc.org/github.com/tolik505/split-csv" target="_blank" rel="noopener noreferrer"><img width="250" src="https://repository-images.githubusercontent.com/212197147/d2207900-e626-11e9-827b-6faac4005ac1" alt="Vue logo"></a></p>
 
 # Split csv
+
 [![GoDoc](https://godoc.org/github.com/tolik505/split-csv?status.svg)](https://godoc.org/github.com/tolik505/split-csv)
 [![Go Report Card](https://goreportcard.com/badge/github.com/tolik505/split-csv?style=flat-square)](https://goreportcard.com/report/github.com/tolik505/split-csv)
 [![codecov](https://codecov.io/gh/tolik505/split-csv/branch/master/graph/badge.svg?token=YRJJN6J5XN)](https://codecov.io/gh/tolik505/split-csv)
@@ -9,10 +10,11 @@
 
 Fast and efficient Golang package for splitting large csv files on smaller chunks by size in bytes.
 
-
 ## Features:
+
 - Super-fast splitting. Splitting of 700MB+ file takes less than 1 sec!
 - Allocates minimum memory regardless file size.
+- Also accepts io.Reader as input.
 - Supports multiline cells and headers (csv should follow the basic rules https://en.wikipedia.org/wiki/Comma-separated_values).
 - Configurable destination folder.
 - Disabling/enabling of copying a header in chunk files.
@@ -43,7 +45,9 @@ func ExampleSplitCsv() {
 	// Output: [testdata/test_1.csv testdata/test_2.csv testdata/test_3.csv]
 }
 ```
+
 If copying of a header in chunks is not needed then:
+
 ```go
 func ExampleSplitCsv() {
 	splitter := splitCsv.New()
@@ -56,5 +60,65 @@ func ExampleSplitCsv() {
 }
 ```
 
+Or if you want to pass io.Reader instead of a file path:
+
+```go
+// First implement io.Reader interface with an appropriate logic for your use-case
+type testReader struct {
+	dataCh chan []byte
+	buf    []byte
+}
+// Read listens to the data channel and populates p accordingly.
+// When p is full remaining data goes to the buffer to be used in the next read cycle
+func (r *testReader) Read(p []byte) (n int, err error) {
+	pLen := len(p)
+	i := 0
+	for _, char := range r.buf {
+		p[i] = char
+		i++
+	}
+	r.buf = nil
+	for bytes := range r.dataCh {
+		for j, char := range bytes {
+			p[i] = byte(char)
+			i++
+			if i >= pLen {
+				r.buf = bytes[j+1:]
+
+				return pLen, nil
+			}
+		}
+	}
+
+	return i, io.EOF
+}
+// In the example data is being sent to the channel which is consumed by the custom reader.
+// In such way we can stream data to the splitter.
+func ExampleSplitCsv() {
+	dataCh := make(chan []byte)
+	reader := &testReader{dataCh: dataCh}
+	data := []string{
+		"Test header 1; Test header 2; Test header 3; Test header 4; Test header 5\n",
+		"1; test value 1st; test value 1st; test value 1st; test value 1st\n",
+		"2; test value 2nd; test value 2nd; test value 2nd; test value 2nd\n",
+		"3; test value 3rd; test value 3rd; test value 3rd; test value 3rd\n",
+	}
+	go func() {
+		defer close(dataCh)
+		for _, v := range data {
+			dataCh <- []byte(v)
+		}
+	}()
+	splitter := splitCsv.New()
+	splitter.Separator = ";"     // "," is by default
+	splitter.FileChunkSize = 100000000 //in bytes (100MB)
+	result, _ := splitter.SplitReader(reader, "output/dir", "output_file_prefix")
+	fmt.Println(result)
+	// Output: [output/dir/test_1.csv output/dir/test_2.csv output/dir/test_3.csv]
+}
+```
+
 ## License
+
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ftolik505%2Fsplit-csv.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Ftolik505%2Fsplit-csv?ref=badge_large)
+

--- a/example_test.go
+++ b/example_test.go
@@ -2,13 +2,14 @@ package split_csv_test
 
 import (
 	"fmt"
+
 	splitCsv "github.com/tolik505/split-csv"
 )
 
 func ExampleSplitCsv() {
 	splitter := splitCsv.New()
 	splitter.Separator = ";"     // "," is by default
-	splitter.FileChunkSize = 800 //in bytes
+	splitter.FileChunkSize = 800 // in bytes
 	result, _ := splitter.Split("testdata/test.csv", "testdata/")
 	fmt.Println(result)
 	// Output: [testdata/test_1.csv testdata/test_2.csv testdata/test_3.csv]

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,12 @@
 module github.com/tolik505/split-csv
 
-go 1.12
+go 1.22
 
 require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/state.go
+++ b/state.go
@@ -6,11 +6,8 @@ import (
 
 type state struct {
 	s             Splitter
-	inputFilePath string
 	fileName      string
-	ext           string
 	resultDirPath string
-	inputFile     io.ReadCloser
 	chunkFile     io.WriteCloser
 	chunkFilePath string
 	header        []byte

--- a/state_factory.go
+++ b/state_factory.go
@@ -2,17 +2,13 @@ package split_csv
 
 import (
 	"bytes"
-	"io"
 )
 
 type stateInitializer interface {
 	Init(
 		s Splitter,
-		inputFilePath string,
 		fileName string,
-		ext string,
 		resultDirPath string,
-		inputFile io.ReadCloser,
 	) *state
 }
 
@@ -20,11 +16,8 @@ type stateFactory struct{}
 
 func (f stateFactory) Init(
 	s Splitter,
-	inputFilePath string,
 	fileName string,
-	ext string,
 	resultDirPath string,
-	inputFile io.ReadCloser,
 ) *state {
 	var header []byte
 	if s.WithHeader {
@@ -33,11 +26,8 @@ func (f stateFactory) Init(
 
 	return &state{
 		s:             s,
-		inputFilePath: inputFilePath,
 		fileName:      fileName,
-		ext:           ext,
 		resultDirPath: resultDirPath,
-		inputFile:     inputFile,
 		isFirstLine:   true,
 		chunk:         1,
 		bulkBuffer:    bytes.NewBuffer(make([]byte, 0, s.bufferSize)),

--- a/testdata/result_custom_reader/test_1.csv.expected
+++ b/testdata/result_custom_reader/test_1.csv.expected
@@ -1,0 +1,5 @@
+Test header 1; Test header 2; Test header 3; Test header 4; Test header 5
+1; test value 1st; test value 1st; test value 1st; test value 1st
+2; test value 2nd; test value 2nd; test value 2nd; test value 2nd
+3; test value 3rd; test value 3rd; test value 3rd; test value 3rd
+4; test value 4th; test value 4th; test value 4th; test value 4th

--- a/testdata/result_custom_reader/test_2.csv.expected
+++ b/testdata/result_custom_reader/test_2.csv.expected
@@ -1,0 +1,6 @@
+Test header 1; Test header 2; Test header 3; Test header 4; Test header 5
+5; test value 5th; test value 5th; test value 5th; test value 5th
+6; test value 6th; test value 6th; test value 6th; test value 6th
+11; test value 1st; test value 1st; test value 1st; test value 1st
+12; test value 2nd; test value 2nd; test value 2nd; test value 2nd
+13; test value 3rd; test value 3rd; test value 3rd; test value 3rd

--- a/testdata/result_custom_reader/test_3.csv.expected
+++ b/testdata/result_custom_reader/test_3.csv.expected
@@ -1,0 +1,4 @@
+Test header 1; Test header 2; Test header 3; Test header 4; Test header 5
+14; test value 4th; test value 4th; test value 4th; test value 4th
+15; test value 5th; test value 5th; test value 5th; test value 5th
+16; test value 6th; test value 6th; test value 6th; test value 6th


### PR DESCRIPTION
Added SplitReader method to be able to pass io.Reader instead of a file path.